### PR TITLE
Add referents to show view and update establishment table

### DIFF
--- a/app/models/establishment_tracking.rb
+++ b/app/models/establishment_tracking.rb
@@ -37,5 +37,7 @@ class EstablishmentTracking < ApplicationRecord
     event :cancel do
       transitions from: :in_progress, to: :cancelled
     end
+
+    #TODO : permettre le passage d'un statut à l'autre sans restrictions (restore ? monitor ?)
   end
 end

--- a/app/views/establishment_trackings/_establishment_trackings_table.html.erb
+++ b/app/views/establishment_trackings/_establishment_trackings_table.html.erb
@@ -6,37 +6,33 @@
           <caption>Tous les accompagnements</caption>
           <thead>
           <tr>
-            <th>ID</th>
-            <th>Statut</th>
+            <th>SIRET</th>
             <th>Raison sociale</th>
-            <th>Département</th>
-            <th>Référents</th>
-            <th>Étiquettes</th>
-            <th>Créé par</th>
+            <th>Statut</th>
             <th>Date de début</th>
-            <th>Actions</th>
+            <th>Référents</th>
+            <th>Participants</th>
+            <th>Étiquettes</th>
+            <th colspan="2">Actions</th>
           </tr>
           </thead>
           <tbody>
             <% @establishment_trackings.each do |tracking| %>
               <tr>
-                <td><%= tracking.id %></td>
-                <td><%= tracking.aasm.human_state %></td>
+                <td><%= tracking.establishment.siret %></td>
                 <td><%= tracking.establishment.raison_sociale %></td>
-                <td><%= tracking.establishment.department.code %></td>
-                <td><%= tracking.referents.map(&:full_name).join(', ') %></td>
-                <td><%= tracking.tracking_labels.map(&:name).join(', ') %></td>
-                <td><%= tracking.creator.full_name %></td>
+                <td><%= tracking.aasm.human_state %></td>
                 <td><%= l(tracking.start_date, format: :long) %></td>
+                <td><%= tracking.referents.map(&:full_name).join(', ') %></td>
+                <td><%= tracking.participants.map(&:full_name).join(', ') %></td>
+                <td><%= tracking.tracking_labels.map(&:name).join(', ') %></td>
                 <td>
-                  <div class="fr-grid-row">
-                    <div class="fr-col-6">
-                      <%= link_to 'Voir cet accompagnement', [tracking.establishment, tracking], class: 'fr-link' %>
-                    </div>
-                    <div class="fr-col-6">
-                      <%= link_to 'Voir tous les accompagnements',tracking.establishment, class: 'fr-link' %>
-                    </div>
-                  </div>
+
+                      <%= link_to 'Consulter', [tracking.establishment, tracking], class: 'fr-btn' %>
+                </td>
+                <td>
+                      <%= link_to 'Fiche l\'établissement',tracking.establishment, class: 'fr-btn fr-btn--secondary' %>
+
                 </td>
               </tr>
             <% end %>

--- a/app/views/establishment_trackings/show.html.erb
+++ b/app/views/establishment_trackings/show.html.erb
@@ -29,6 +29,9 @@
     <p><strong>Date de début:</strong> <%= @establishment_tracking.start_date %></p>
     <p><strong>Date de fin:</strong> <%= @establishment_tracking.end_date %></p>
     <p><strong>État actuel:</strong> <%= @establishment_tracking.aasm.human_state %></p>
+    <p><strong>Assignés:</strong>
+      <%= @establishment_tracking.referents.map { |participant| full_name(participant) }.join(', ') %>
+    </p>
     <p><strong>Participants:</strong>
       <%= @establishment_tracking.participants.map { |participant| full_name(participant) }.join(', ') %>
     </p>

--- a/lib/tasks/import_from_wekan.rake
+++ b/lib/tasks/import_from_wekan.rake
@@ -6,8 +6,8 @@ require 'mongo'
 
 namespace :import_from_wekan do
   desc "Import user data from wekan (MongoDB) to rails users table (PostgreSQL)"
+  #TODO Do we really need this ? We can import users from the habilitations file
   task users: :environment do
-    # MongoDB connection setup
     mongo_host = ENV['MONGO_DB_HOST'] || 'wekan-db' # The name of the wekan db podman container in local dev mode
     mongo_port = ENV['MONGO_DB_PORT'] || '27017'
     mongo_db_name = ENV['MONGO_DB_NAME'] || 'test'
@@ -48,4 +48,75 @@ namespace :import_from_wekan do
 
     puts "Wekan data import completed."
   end
+
+  namespace :import_from_wekan do
+    desc "Import cards from Wekan and create corresponding Rails models"
+    task cards: :environment do
+      mongo_host = ENV['MONGO_DB_HOST'] || 'wekan-db'
+      mongo_port = ENV['MONGO_DB_PORT'] || '27017'
+      mongo_db_name = ENV['MONGO_DB_NAME'] || 'test'
+
+      client = Mongo::Client.new(["#{mongo_host}:#{mongo_port}"], database: mongo_db_name)
+
+      boards = client[:boards]
+      swimlanes = client[:swimlanes]
+      cards = client[:cards]
+
+      #TODO target the boards we want based on their names (have to include 'crp')
+      target_boards = boards.find({ name: { "$in": ['Board 1', 'Board 2'] } })
+      target_swimlanes = swimlanes.find({ boardId: { "$in": target_boards.map { |board| board['_id'] } } })
+
+      # Iterate over each swimlane (a swimlane seems to be a department) and its cards
+      target_swimlanes.each do |swimlane|
+        puts "Processing swimlane: #{swimlane['title']}"
+
+        swimlane_cards = cards.find({ swimlaneId: swimlane['_id'] })
+
+        # TODO Determine how to work on columns and do the mapping between the columns names and the EstablishmentTracking state machine statuses
+        swimlane_cards.each do |card|
+          # Print the card's details (or perform operations with the card)
+          puts "Processing card: #{card['title']}"
+
+          # Here we will create the Establishment, EstablishmentTracking, Summary, Comment, etc.
+
+          # Creating an Establishment skeleton
+          establishment = Establishment.find_or_create_by(siret: card['customField_siret']) do |e|
+            e.raison_sociale = card['title']
+            e.department = Department.find_by(code: card['customField_department'])
+          end
+
+          # Creating an EstablishmentTracking skeleton
+          tracking = EstablishmentTracking.find_or_create_by(establishment: establishment) do |t|
+            t.creator = User.first #TODO : determine how to retrieve the user
+            t.start_date = Date.today
+            t.status = 'active'
+          end
+
+          # Creating a Summary skeleton
+          summary = Summary.create!(
+            content: card['description'],
+            establishment_tracking: tracking,
+            is_codefi: false #CODEFI is false because we are only importing crp cards
+          )
+
+          # Creating a Comment skeleton
+          comment = Comment.create!(
+            content: card['comment'],
+            establishment_tracking: tracking,
+            user: User.first #TODO : determine how to retrieve the user
+          )
+
+          # Creating Labels skeleton
+          tracking_label = TrackingLabel.find_or_create_by(name: card['customField_label'])
+          EstablishmentTrackingLabel.create!(establishment_tracking: tracking, tracking_label: tracking_label)
+        end
+      end
+
+      client.close
+
+      puts "Wekan crp cards import completed!"
+    end
+  end
+
+
 end


### PR DESCRIPTION
Added the referents field to the establishment trackings show view and reorganized columns in the establishment trackings table view. Also, included an initial setup for importing Wekan cards, which now creates Establishment and associated models in the database.