### PR TITLE
Add unique index and validations for 'in_progress' trackings

### DIFF
--- a/app/models/establishment_tracking.rb
+++ b/app/models/establishment_tracking.rb
@@ -21,6 +21,8 @@ class EstablishmentTracking < ApplicationRecord
 
   validates :referents, presence: true
 
+  validate :single_in_progress_tracking, if: :in_progress?
+
   scope :in_progress, -> { where(state: 'in_progress') }
   scope :completed, -> { where(state: 'completed') }
   scope :cancelled, -> { where(state: 'cancelled') }
@@ -56,6 +58,14 @@ class EstablishmentTracking < ApplicationRecord
 
     event :resume do
       transitions from: [:completed, :under_surveillance, :in_progress], to: :in_progress
+    end
+  end
+
+  private
+
+  def single_in_progress_tracking
+    if establishment.establishment_trackings.where(state: 'in_progress').where.not(id: id).exists?
+      errors.add(:state, 'Il ne peut y avoir qu\'un seul accompagnement en cours pour un établissement donné')
     end
   end
 end

--- a/app/views/establishments/show.html.erb
+++ b/app/views/establishments/show.html.erb
@@ -3,11 +3,11 @@
 
     <h1>Historique des accompagnements - <%= @establishment&.raison_sociale %></h1>
 
-    <% if @in_progress_trackings.empty? %>
+<!--
       <button class="fr-btn">
-        <%= link_to 'Ajouter un nouvel accompagnement', new_establishment_establishment_tracking_path(@establishment) %>
+        <%#= link_to 'Ajouter un nouvel accompagnement', new_establishment_establishment_tracking_path(@establishment) %>
       </button>
-    <% end %>
+-->
 
     <% if @in_progress_trackings.any? %>
       <%= render partial: 'establishments/establishment_trackings_table_light', locals: { trackings: @in_progress_trackings, title: 'Accompagnements en cours' } %>

--- a/db/migrate/20241010084904_add_unique_index_to_establishment_trackings_in_progress.rb
+++ b/db/migrate/20241010084904_add_unique_index_to_establishment_trackings_in_progress.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToEstablishmentTrackingsInProgress < ActiveRecord::Migration[7.1]
+  def change
+    add_index :establishment_trackings,
+              [:establishment_id, :state],
+              unique: true,
+              where: "state = 'in_progress'",
+              name: 'index_single_in_progress_per_establishment'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_07_140347) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_10_084904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_140347) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_establishment_trackings_on_creator_id"
+    t.index ["establishment_id", "state"], name: "index_single_in_progress_per_establishment", unique: true, where: "((state)::text = 'in_progress'::text)"
     t.index ["establishment_id"], name: "index_establishment_trackings_on_establishment_id"
   end
 

--- a/db/seeds/trackings_seeds.rb
+++ b/db/seeds/trackings_seeds.rb
@@ -5,29 +5,25 @@ establishments = Establishment.all
 
 establishments.each do |establishment|
   if rand < 0.3
-    number_of_trackings = rand < 0.5 ? 1 : rand(2..3)
+    creator = users.sample
+    referents = users.sample(rand(1..2))
+    referents << creator unless referents.include?(creator)
 
-    number_of_trackings.times do
-      creator = users.sample
-      referents = users.sample(rand(1..2))
-      referents << creator unless referents.include?(creator)
+    tracking = EstablishmentTracking.new(
+      creator: creator,
+      establishment: establishment,
+      start_date: Faker::Date.backward(days: 365),
+      end_date: Faker::Date.forward(days: 365),
+    )
 
-      tracking = EstablishmentTracking.new(
-        creator: creator,
-        establishment: establishment,
-        start_date: Faker::Date.backward(days: 365),
-        end_date: Faker::Date.forward(days: 365),
-      )
+    tracking.referents = referents
 
-      tracking.referents = referents
+    tracking.save!
 
-      tracking.save!
+    participants = users.sample(rand(1..10))
 
-      participants = users.sample(rand(1..10))
-
-      participants.each do |participant|
-        TrackingParticipant.create!(user: participant, establishment_tracking: tracking)
-      end
+    participants.each do |participant|
+      TrackingParticipant.create!(user: participant, establishment_tracking: tracking)
     end
   end
 end


### PR DESCRIPTION
Ensure only one 'in_progress' tracking per establishment by adding a unique index and validation. Updated the seeding logic to align with this restriction and commented out button for adding new tracking if one is already in progress.