### PR TITLE
Exclude 'CODEFI' network from views and tests

### DIFF
--- a/app/views/establishment_trackings/show.html.erb
+++ b/app/views/establishment_trackings/show.html.erb
@@ -35,7 +35,7 @@
       </li>
 
       <!-- User Networks Tabs -->
-      <% current_user.networks.each do |network| %>
+      <% current_user.networks.where.not(name: 'CODEFI').each do |network| %>
         <li role="presentation">
           <button id="tabpanel-<%= network.name.parameterize %>"
                   class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left"
@@ -51,7 +51,7 @@
     <%= render 'info_panel' %>
 
     <!-- User Networks Panels -->
-    <% current_user.networks.each do |network| %>
+    <% current_user.networks.where.not(name: 'CODEFI').each do |network| %>
       <div id="tabpanel-<%= network.name.parameterize %>-panel"
            class="fr-tabs__panel"
            role="tabpanel"

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,12 +35,12 @@
           <div class="fr-header__tools-links">
             <ul class="fr-btns-group">
               <li>
-                <% if current_user != true_user && current_user.segment.name != "sf" %>
+                <% if current_user != true_user && current_user&.segment&.name != "sf" %>
                   <%= button_to("Retour à l'admin", stop_impersonating_users_path, data: { turbo: false },  class: 'fr-btn fr-icon-settings-5-fill') %>
                 <% end %>
               </li>
               <li>
-                  <% if current_user.segment.name == "sf" %>
+                  <% if current_user&.segment&.name == "sf" %>
                     <%= link_to admin_root_path, class: 'fr-btn fr-icon-settings-5-fill' do %>
                       Administration centrale
                     <% end %>

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -86,7 +86,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     get establishment_establishment_tracking_path(@establishment, @establishment_tracking)
 
-    @user_a.networks.each do |network|
+    @user_a.networks.where.not(name: 'CODEFI').each do |network|
       assert_select "form[action=?]", establishment_establishment_tracking_comments_path(@establishment, @establishment_tracking)
       assert_select "input[type=hidden][value=?]", network.id.to_s
     end

--- a/test/controllers/summaries_controller_test.rb
+++ b/test/controllers/summaries_controller_test.rb
@@ -13,17 +13,16 @@ class SummariesControllerTest < ActionDispatch::IntegrationTest
 
   end
 
-  test "user A sees tabs for CODEFI and CRP networks" do
+  test "user A sees tabs CRP networks" do
     sign_in @user_a
 
     get establishment_establishment_tracking_path(@establishment, @establishment_tracking)
 
     assert_select "button", text: "Informations", count: 1
-    assert_select "button", text: "CODEFI", count: 1
     assert_select "button", text: "CRP", count: 1
 
     # The user should only see three tabs (one for establishment details, his/her network and one for the CODEFI network)
-    assert_select "button.fr-tabs__tab", count: 3
+    assert_select "button.fr-tabs__tab", count: 2
   end
 
   test "user A can lock and edit the summary" do

--- a/test/fixtures/summaries.yml
+++ b/test/fixtures/summaries.yml
@@ -1,4 +1,4 @@
 summary_paris_crp:
   content: 'Dummy content'
   establishment_tracking: establishment_tracking_paris
-  network: network_codefi
+  network: network_crp

--- a/test/integration/establishment_tracking_show_test.rb
+++ b/test/integration/establishment_tracking_show_test.rb
@@ -19,26 +19,26 @@ class EstablishmentTrackingShowTest < ActionDispatch::IntegrationTest
     get establishment_establishment_tracking_path(@establishment_tracking.establishment, @establishment_tracking)
 
     assert_select "form[action*='/summaries']" do |forms|
-      assert_equal 2, forms.size
+      assert_equal 1, forms.size
 
       forms.each do |form|
         hidden_field = form.css("input[type=hidden][name='summary[network_id]']")
         assert hidden_field.present?, "Each form should have a hidden field for network_id"
         network_id = hidden_field.attr("value").to_s
         network = Network.find(network_id)
-        assert_includes ["CODEFI", "CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
+        assert_includes ["CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
       end
     end
 
     assert_select "form[action*='/comments']" do |forms|
-      assert_equal 2, forms.size
+      assert_equal 1, forms.size
 
       forms.each do |form|
         hidden_field = form.css("input[type=hidden][name='comment[network_id]']")
         assert hidden_field.present?, "Each form should have a hidden field for network_id"
         network_id = hidden_field.attr("value").to_s
         network = Network.find(network_id)
-        assert_includes ["CODEFI", "CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
+        assert_includes ["CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
       end
     end
 
@@ -57,14 +57,14 @@ class EstablishmentTrackingShowTest < ActionDispatch::IntegrationTest
     get establishment_establishment_tracking_path(@establishment_tracking.establishment, @establishment_tracking)
 
     assert_select "form[action*='/summaries']" do |forms|
-      assert_equal 2, forms.size
+      assert_equal 1, forms.size
 
       forms.each do |form|
         hidden_field = form.css("input[type=hidden][name='summary[network_id]']")
         assert hidden_field.present?, "Each form should have a hidden field for network_id"
         network_id = hidden_field.attr("value").to_s
         network = Network.find(network_id)
-        assert_includes ["CODEFI", "CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
+        assert_includes ["CRP"], network.name, "The network_id should correspond to CODEFI or CRP"
       end
     end
 


### PR DESCRIPTION
This commit updates various views and tests to exclude the 'CODEFI' network. The changes ensure that only relevant networks, specifically 'CRP', are displayed and tested, improving the accuracy and relevance of the application's functionality for the intended context. Additionally, it ensures checks for null values on user segments for better reliability in header views.