### PR TITLE
Remove inline-block display style from summary div.

### DIFF
--- a/app/views/summaries/_summary.html.erb
+++ b/app/views/summaries/_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="fr-p-3w" style="border: #6A6AF4 1px solid; display: inline-block;">
+<div class="fr-p-3w" style="border: #6A6AF4 1px solid">
   <div style="display: flex; justify-content: space-between; align-items: center;">
     <h4>Synthèse du <%= summary.created_at.present? ? l(summary.created_at, format: :custom) : '-' %></h4>
     <% if policy(@establishment_tracking).edit? %>


### PR DESCRIPTION
The `inline-block` display style was removed from the div containing the summary to potentially resolve layout issues or migrate to a more cohesive styling structure. This change ensures that the div conforms to its context without the need for inline display adjustments.