### PR TITLE
Add session-based filter persistence and resetting logic

### DIFF
--- a/app/controllers/establishment_trackings_controller.rb
+++ b/app/controllers/establishment_trackings_controller.rb
@@ -4,7 +4,16 @@ class EstablishmentTrackingsController < ApplicationController
   before_action :set_system_labels, only: %i[new new_by_siret edit update create]
 
   def index
-    # Storing user's layout choice (cards or table)
+    if params[:clear_filters]
+      session[:establishment_tracking_filters] = nil
+      params[:q] = {}
+    elsif params[:q].present?
+      session[:establishment_tracking_filters] = params[:q]
+    elsif session[:establishment_tracking_filters].present?
+      params[:q] = session[:establishment_tracking_filters]
+    end
+
+    # Storing user's layout choice (cards or table). TODO put it in the session
     @current_view = params.dig(:q, :view) || "table"
 
     # Removing `view` from `q` so it doesn't affect Ransack

--- a/app/views/establishment_trackings/_establishment_trackings_table.html.erb
+++ b/app/views/establishment_trackings/_establishment_trackings_table.html.erb
@@ -32,7 +32,7 @@
     </div>
   </div>
 </div>
-<div data-view-toggle-target="tableView" style="<%= @current_view == 'cards' ? 'display: none;' : 'display: block;' %>">
+<div id="results" data-view-toggle-target="tableView" style="<%= @current_view == 'cards' ? 'display: none;' : 'display: block;' %>">
 
   <div class="fr-table" id="table-md-component">
     <div class="fr-table__wrapper">
@@ -117,6 +117,6 @@
 </div>
 
 <div class="fr-mt-3w fr-mb-3w" data-view-toggle-target="pagination">
-  <%= paginate @paginated_establishment_trackings, params: { q: params[:q]&.permit! } %>
+  <%= paginate @paginated_establishment_trackings, params: { q: params[:q]&.permit!, anchor: 'results' } %>
 </div>
 

--- a/app/views/establishment_trackings/_filters.html.erb
+++ b/app/views/establishment_trackings/_filters.html.erb
@@ -131,7 +131,7 @@
               <%= params.dig(:q, :filters_open) == "true" ? 'Réduire les critères supplémentaires' : 'Afficher des critères supplémentaires' %>
             <% end %>
             <%= f.submit "Filtrer", class: "fr-btn" %>
-            <%= link_to "Réinitialiser les filtres", establishment_trackings_path, class: "fr-btn fr-btn--secondary" %>
+            <%= link_to "Réinitialiser les filtres", establishment_trackings_path(clear_filters: true), class: "fr-btn fr-btn--secondary", data: { turbo: false} %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Filters in the establishment trackings page now persist across requests using the session, and users can reset them with a "Réinitialiser les filtres" button. Updated "Filtrer"