### PR TITLE
Fix filter clearing to redirect to index properly

### DIFF
--- a/app/controllers/establishment_trackings_controller.rb
+++ b/app/controllers/establishment_trackings_controller.rb
@@ -196,7 +196,7 @@ class EstablishmentTrackingsController < ApplicationController
   def handle_filters(params)
     if params[:clear_filters]
       session[:establishment_tracking_filters] = nil
-      {}
+      redirect_to action: :index and {}
     elsif params[:q].present?
       session[:establishment_tracking_filters] = params[:q]
       params[:q]


### PR DESCRIPTION
Previously, clearing filters did not redirect the user to the index page, potentially causing confusion. This change ensures the user is redirected to the appropriate page when filters are cleared.