### PR TITLE
Add Stimulus controller for download button with feedback

### DIFF
--- a/app/javascript/controllers/download_controller.js
+++ b/app/javascript/controllers/download_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["button"];
+
+    async disable(event) {
+        event.preventDefault();
+
+        // Store the parent element and original HTML
+        const parent = this.buttonTarget.parentNode;
+        const originalHTML = parent.innerHTML;
+
+        parent.innerHTML = `<span class="disabled">Téléchargement en cours...</span>`;
+
+        try {
+            const response = await fetch(this.buttonTarget.getAttribute("href"));
+
+            if (!response.ok) {
+                throw new Error("Download failed");
+            }
+
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = this.getFilenameFromResponse(response);
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error("Error during download:", error);
+            alert("Une erreur est survenue pendant le téléchargement.");
+        } finally {
+            // Restore the original link HTML
+            parent.innerHTML = originalHTML;
+
+            // Re-attach the Stimulus controller
+            this.connect();
+        }
+    }
+
+    getFilenameFromResponse(response) {
+        const contentDisposition = response.headers.get("content-disposition");
+        const match = contentDisposition?.match(/filename="(.+)"/);
+        return match ? match[1] : "download.xlsx";
+    }
+}

--- a/app/services/establishment_tracking_excel_generator.rb
+++ b/app/services/establishment_tracking_excel_generator.rb
@@ -25,14 +25,15 @@ class EstablishmentTrackingExcelGenerator
         summary = tracking.summaries.find_by(network: @user.non_codefi_network)
         sheet.add_row [
                         tracking.establishment.raison_sociale,
-                        tracking.establishment.siret,
-                        tracking.establishment&.department.name,
+                        tracking.establishment.siret.to_s,
+                        tracking.establishment&.department&.name,
                         tracking.participants.map(&:full_name).join(', '),
                         tracking.referents.map(&:full_name).join(', '),
                         tracking.start_date.present? ? tracking.start_date.strftime('%d/%m/%Y') : '-',
                         tracking.aasm.human_state,
                         summary&.content || 'Aucune synthèse rédigée'
-                      ]
+                      ],
+                      types: [nil, :string, nil, nil, nil, nil, nil, nil]
       end
     end
   end

--- a/app/views/establishment_trackings/_establishment_trackings_table.html.erb
+++ b/app/views/establishment_trackings/_establishment_trackings_table.html.erb
@@ -6,7 +6,10 @@
 
 <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
   <div class="fr-col-6">
-    <%= link_to establishment_trackings_path(format: :xlsx, q: params[:q]&.permit!), class: 'fr-link--download fr-link', download: "true" do %>
+    <%= link_to establishment_trackings_path(format: :xlsx, q: params[:q]&.permit!),
+                class: 'fr-link--download fr-link',
+                data: { controller: 'download', action: 'click->download#disable', download_target: 'button' },
+                id: 'download-button' do %>
       Télécharger les <%= @paginated_establishment_trackings.total_count %> résultats de la recherche
       <span class="fr-link__detail">XLS</span>
     <% end %>


### PR DESCRIPTION
Introduced a Stimulus controller to handle download button functionality, providing user feedback during file downloads. Updated the Excel generator to improve data formatting and fixed a potential issue with missing department names. Adjusted the view to integrate the new controller for a smoother user experience.