### PR TITLE
removed secret key base from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,5 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-ENV SECRET_KEY_BASE=1
 
 CMD ["./bin/rails", "server"]


### PR DESCRIPTION
this should be set from Ansible because secrets stored in the image itself could be accessible. And the value should not be 1.