### PR TITLE
Remove "no comments" message dynamically upon new comment

### DIFF
--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -11,3 +11,5 @@
     <%= notice %>
   </div>
 <% end %>
+
+<%= turbo_stream.remove "no_comments_message_#{@comment.network.name.parameterize}" %>

--- a/app/views/establishment_trackings/show.html.erb
+++ b/app/views/establishment_trackings/show.html.erb
@@ -104,7 +104,7 @@
                         <%= render "comments/comment", comment: comment %>
                       <% end %>
                     <% else %>
-                      <p>Il n'y a pas encore de commentaires pour ce suivi</p>
+                      <p id="no_comments_message_<%= network.name.parameterize %>">Il n'y a pas encore de commentaires pour ce suivi</p>
                     <% end %>
                   <% end %>
                 </div>


### PR DESCRIPTION
Added Turbo Stream functionality to remove the "no comments" message when a new comment is created. Updated the message tag in the view to include a unique ID for proper targeting. This ensures a seamless user experience when interacting with comments.