### PR TITLE
rake task to udpate trackings modification date

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <div class="comment-footer">
-      <span>le <%= l(comment.created_at, format: :custom) %> (il y a <%= time_ago_in_words(comment.created_at) %>)</span>
+      <span>le <%= l(comment.updated_at, format: :custom) %> (il y a <%= time_ago_in_words(comment.updated_at) %>)</span>
       <% if comment.user == current_user %>
         <%= link_to "Modifier", edit_establishment_establishment_tracking_comment_path(@establishment, @establishment_tracking, comment), data: { turbo_frame: dom_id(comment), turbo_stream: true, action: "auto-resize#focus" }, class: "edit-link", title: "Modifier ce commentaire" %>
         <%= link_to "Supprimer", establishment_establishment_tracking_comment_path(@establishment, @establishment_tracking, comment), method: :delete, data: { turbo_confirm: "Êtes-vous sûr ?", turbo_method: :delete, turbo_stream: true }, class: "delete-link", title: "Supprimer ce commentaire" %>

--- a/app/views/establishment_trackings/_info_panel.html.erb
+++ b/app/views/establishment_trackings/_info_panel.html.erb
@@ -21,7 +21,6 @@
         <p>
           <strong>Criticité :</strong> <%= @establishment_tracking.criticality&.name || 'Pas de criticité renseignée' %>
         </p>
-
         <p>
           <strong>Etiquettes :</strong>
           <% if @establishment_tracking.tracking_labels.any? %>

--- a/lib/tasks/force_trackings_modified_at.rake
+++ b/lib/tasks/force_trackings_modified_at.rake
@@ -1,0 +1,27 @@
+# lib/tasks/force_trackings_modified_at.rake
+# Force the update of the modified_at attribute for all EstablishmentTrackings if a more recent summary or comment is found
+# usage : rake trackings:update_modified_at
+
+namespace :trackings do
+  desc "Analyse et met à jour la date de dernière modification de tous les accompagnements"
+  task update_modified_at: :environment do
+    puts "Mise à jour des dates de modifications des accompagnements..."
+
+    EstablishmentTracking.find_each do |tracking|
+      last_modification_date = tracking.modified_at
+      last_comment_date = tracking.comments.maximum(:updated_at)
+      last_summary_date = tracking.summaries.maximum(:updated_at)
+
+      most_recent_date = [last_modification_date, last_comment_date, last_summary_date].compact.max
+
+      if most_recent_date && most_recent_date > last_modification_date
+        tracking.update(modified_at: most_recent_date)
+        puts "Mise à jour pour l'accompagnement #{tracking.id} : Nouvelle date #{most_recent_date}"
+      else
+        puts "Aucune mise à jour nécessaire pour l'accompagnement #{tracking.id}."
+      end
+    end
+
+    puts "Mise à jour terminée !"
+  end
+end


### PR DESCRIPTION
Replaced comment creation timestamp with the updated timestamp in comment templates to reflect recent changes. Added a rake task to ensure `modified_at` on `EstablishmentTrackings` accounts for the latest comment or summary updates. Cleaned up extra whitespace in the views.