### PR TITLE
Add INPI BCE ratios to list export

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -11,6 +11,7 @@ class Company < ApplicationRecord
   has_many :company_score_entries, foreign_key: :siren, primary_key: :siren, dependent: :destroy
   has_many :osf_procols, foreign_key: :siren, primary_key: :siren, dependent: :destroy
   has_many :company_list_ratings, foreign_key: :siren, primary_key: :siren, dependent: :destroy
+  has_many :inpi_bce_ratios, foreign_key: :siren, primary_key: :siren, dependent: :destroy
 
   validates :siren, presence: true, uniqueness: true
   validates :department, presence: true, length: { maximum: 10 }

--- a/app/models/inpi_bce_ratio.rb
+++ b/app/models/inpi_bce_ratio.rb
@@ -1,0 +1,8 @@
+class InpiBceRatio < ApplicationRecord
+  belongs_to :company, foreign_key: :siren, primary_key: :siren, optional: false
+
+  validates :siren, presence: true, length: { is: 9 }
+  validates :date_cloture_exercice, presence: true
+  validates :type_bilan, presence: true, length: { maximum: 1 }
+  validates :siren, uniqueness: { scope: %i[date_cloture_exercice type_bilan] }
+end

--- a/app/services/excel/list_generator.rb
+++ b/app/services/excel/list_generator.rb
@@ -52,6 +52,7 @@ module Excel
       @score_entries_by_company = {}
       @has_delai_urssaf = Set.new
       @company_data = {} # Cache for company metadata (raison_sociale, department, etc.)
+      @inpi_bce_ratios = {}
     end
 
     def generate
@@ -108,11 +109,16 @@ module Excel
         "Liste retraitée (Oui / Non)",
         "Délai de paiement Urssaf",
         "Entreprises récentes",
-        "Accompagnement"
+        "Accompagnement",
+        "Taux endettement",
+        "CA",
+        "Résultat net",
+        "Résultat d'exploitation",
+        "Ratio de liquidité"
       ]
-      # Reuse single style object instead of creating 24
+      # Reuse single style object instead of creating 29
       header_style_obj = header_style(sheet)
-      sheet.add_row headers, style: Array.new(24, header_style_obj)
+      sheet.add_row headers, style: Array.new(29, header_style_obj)
     end
 
     def add_company_rows(sheet)
@@ -185,6 +191,26 @@ module Excel
               AND l.list_date > ?
               AND l.list_date < ?
           )
+        ),
+        latest_inpi_bce_ratios AS (
+          SELECT DISTINCT ON (ibr.siren)
+            ibr.siren,
+            ibr.taux_d_endettement,
+            ibr.chiffre_d_affaires,
+            ibr.resultat_net,
+            ibr.ebit,
+            ibr.ratio_de_liquidite
+          FROM inpi_bce_ratios ibr
+          INNER JOIN target_sirens ts_filter ON ts_filter.siren = ibr.siren
+          ORDER BY ibr.siren,
+            ibr.date_cloture_exercice DESC,
+            CASE ibr.type_bilan
+              WHEN 'K' THEN 1
+              WHEN 'C' THEN 2
+              WHEN 'S' THEN 3
+              ELSE 4
+            END,
+            ibr.id DESC
         )
         SELECT ts.siren, cm.siret_siege, ls.score, ls.alert,
           ls.score_effectif, ls.score_financier, ls.score_dettes, ls.score_ap,
@@ -196,12 +222,18 @@ module Excel
           cm.social_debt_total,
           CASE WHEN sc.siren IS NOT NULL THEN true ELSE false END AS is_sjcf,
           cm.tracking_status,
-          cm.has_delai_urssaf
+          cm.has_delai_urssaf,
+          libr.taux_d_endettement,
+          libr.chiffre_d_affaires,
+          libr.resultat_net,
+          libr.ebit,
+          libr.ratio_de_liquidite
         FROM target_sirens ts
         LEFT JOIN list_scores ls ON ts.siren = ls.siren
         LEFT JOIN sjcf_companies sc ON ts.siren = sc.siren
         LEFT JOIN company_metadata cm ON ts.siren = cm.siren
         LEFT JOIN first_alert_sirens fa ON ts.siren = fa.siren
+        LEFT JOIN latest_inpi_bce_ratios libr ON ts.siren = libr.siren
         ORDER BY ts.siren
       SQL
 
@@ -278,6 +310,14 @@ module Excel
         # Delai URSSAF
         @has_delai_urssaf.add(siren) if row["has_delai_urssaf"]
 
+        @inpi_bce_ratios[siren] = {
+          taux_d_endettement: row["taux_d_endettement"],
+          chiffre_d_affaires: row["chiffre_d_affaires"],
+          resultat_net: row["resultat_net"],
+          ebit: row["ebit"],
+          ratio_de_liquidite: row["ratio_de_liquidite"]
+        }
+
         # Company metadata (convert date strings to Date objects)
         creation_date = row["creation"]
         creation_date = creation_date.to_date if creation_date.is_a?(String)
@@ -303,6 +343,7 @@ module Excel
 
       # Get score entry for current list specifically (always a hash from single query)
       score_entry = @score_entries_by_company[siren]
+      inpi_bce_ratio = @inpi_bce_ratios[siren] || {}
 
       # Get department code - company_data[:department] is already the code string
       department_code = company_data[:department] || "-"
@@ -331,7 +372,12 @@ module Excel
         format_sjcf(siren),
         format_delai_urssaf(siren),
         format_entreprise_recente(company_data[:creation]),
-        format_tracking_status(siren)
+        format_tracking_status(siren),
+        format_inpi_bce_ratio(inpi_bce_ratio[:taux_d_endettement]),
+        format_inpi_bce_ratio(inpi_bce_ratio[:chiffre_d_affaires]),
+        format_inpi_bce_ratio(inpi_bce_ratio[:resultat_net]),
+        format_inpi_bce_ratio(inpi_bce_ratio[:ebit]),
+        format_inpi_bce_ratio(inpi_bce_ratio[:ratio_de_liquidite])
       ]
     end
 
@@ -435,6 +481,10 @@ module Excel
     def format_tracking_status(siren)
       # Use preloaded tracking status
       @tracking_statuses[siren] || "Pas d'accompagnement"
+    end
+
+    def format_inpi_bce_ratio(value)
+      value.nil? ? "-" : value
     end
 
     def add_filter_details_sheet(workbook)

--- a/db/migrate/20260511134000_create_inpi_bce_ratios.rb
+++ b/db/migrate/20260511134000_create_inpi_bce_ratios.rb
@@ -1,5 +1,5 @@
 class CreateInpiBceRatios < ActiveRecord::Migration[7.2]
-  def change
+  def change # rubocop:disable Metrics/MethodLength
     create_table :inpi_bce_ratios do |t|
       t.string :siren, limit: 9, null: false
       t.date :date_cloture_exercice, null: false

--- a/db/migrate/20260511134000_create_inpi_bce_ratios.rb
+++ b/db/migrate/20260511134000_create_inpi_bce_ratios.rb
@@ -1,0 +1,40 @@
+class CreateInpiBceRatios < ActiveRecord::Migration[7.2]
+  def change
+    create_table :inpi_bce_ratios do |t|
+      t.string :siren, limit: 9, null: false
+      t.date :date_cloture_exercice, null: false
+      t.bigint :chiffre_d_affaires
+      t.bigint :marge_brute
+      t.bigint :ebe
+      t.bigint :ebit
+      t.bigint :resultat_net
+      t.decimal :taux_d_endettement, precision: 20, scale: 6
+      t.decimal :ratio_de_liquidite, precision: 20, scale: 6
+      t.decimal :ratio_de_vetuste, precision: 20, scale: 6
+      t.decimal :autonomie_financiere, precision: 20, scale: 6
+      t.decimal :poids_bfr_exploitation_sur_ca, precision: 20, scale: 6
+      t.decimal :couverture_des_interets, precision: 20, scale: 6
+      t.decimal :caf_sur_ca, precision: 20, scale: 6
+      t.decimal :capacite_de_remboursement, precision: 20, scale: 6
+      t.decimal :marge_ebe, precision: 20, scale: 6
+      t.decimal :resultat_courant_avant_impots_sur_ca, precision: 20, scale: 6
+      t.decimal :poids_bfr_exploitation_sur_ca_jours, precision: 20, scale: 6
+      t.decimal :rotation_des_stocks_jours, precision: 20, scale: 6
+      t.decimal :credit_clients_jours, precision: 20, scale: 6
+      t.decimal :credit_fournisseurs_jours, precision: 20, scale: 6
+      t.string :type_bilan, limit: 1, null: false
+      t.string :confidentiality
+
+      t.timestamps
+    end
+
+    add_index :inpi_bce_ratios, :siren
+    add_index :inpi_bce_ratios,
+              %i[siren date_cloture_exercice type_bilan],
+              unique: true,
+              name: "idx_inpi_bce_ratios_unique_period_type"
+    add_index :inpi_bce_ratios,
+              %i[siren date_cloture_exercice],
+              name: "idx_inpi_bce_ratios_latest_by_siren"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_07_144800) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_11_134000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -399,6 +399,37 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_144800) do
     t.date "data_freshness"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "inpi_bce_ratios", force: :cascade do |t|
+    t.string "siren", limit: 9, null: false
+    t.date "date_cloture_exercice", null: false
+    t.bigint "chiffre_d_affaires"
+    t.bigint "marge_brute"
+    t.bigint "ebe"
+    t.bigint "ebit"
+    t.bigint "resultat_net"
+    t.decimal "taux_d_endettement", precision: 20, scale: 6
+    t.decimal "ratio_de_liquidite", precision: 20, scale: 6
+    t.decimal "ratio_de_vetuste", precision: 20, scale: 6
+    t.decimal "autonomie_financiere", precision: 20, scale: 6
+    t.decimal "poids_bfr_exploitation_sur_ca", precision: 20, scale: 6
+    t.decimal "couverture_des_interets", precision: 20, scale: 6
+    t.decimal "caf_sur_ca", precision: 20, scale: 6
+    t.decimal "capacite_de_remboursement", precision: 20, scale: 6
+    t.decimal "marge_ebe", precision: 20, scale: 6
+    t.decimal "resultat_courant_avant_impots_sur_ca", precision: 20, scale: 6
+    t.decimal "poids_bfr_exploitation_sur_ca_jours", precision: 20, scale: 6
+    t.decimal "rotation_des_stocks_jours", precision: 20, scale: 6
+    t.decimal "credit_clients_jours", precision: 20, scale: 6
+    t.decimal "credit_fournisseurs_jours", precision: 20, scale: 6
+    t.string "type_bilan", limit: 1, null: false
+    t.string "confidentiality"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["siren", "date_cloture_exercice", "type_bilan"], name: "idx_inpi_bce_ratios_unique_period_type", unique: true
+    t.index ["siren", "date_cloture_exercice"], name: "idx_inpi_bce_ratios_latest_by_siren"
+    t.index ["siren"], name: "index_inpi_bce_ratios_on_siren"
   end
 
   create_table "list_export_logs", force: :cascade do |t|

--- a/test/services/excel/list_generator_test.rb
+++ b/test/services/excel/list_generator_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "nokogiri"
+require "zip"
+
+module Excel
+  class ListGeneratorTest < ActiveSupport::TestCase
+    test "exports latest INPI BCE ratios for each company" do
+      company = companies(:company_paris)
+      list = lists(:list_test_2025)
+
+      InpiBceRatio.create!(
+        siren: company.siren,
+        date_cloture_exercice: Date.new(2022, 12, 31),
+        type_bilan: "C",
+        chiffre_d_affaires: 900_000,
+        resultat_net: 40_000,
+        ebit: 70_000,
+        taux_d_endettement: 12.5,
+        ratio_de_liquidite: 110.25
+      )
+      InpiBceRatio.create!(
+        siren: company.siren,
+        date_cloture_exercice: Date.new(2023, 12, 31),
+        type_bilan: "C",
+        chiffre_d_affaires: 1_234_567,
+        resultat_net: -12_345,
+        ebit: 67_890,
+        taux_d_endettement: 45.123456,
+        ratio_de_liquidite: 98.765432
+      )
+
+      xlsx = ListGenerator.new(
+        list,
+        Company.where(siren: company.siren),
+        {},
+        users(:user_crp_paris)
+      ).generate
+
+      rows = worksheet_rows(xlsx)
+
+      assert_equal "Taux endettement", rows.first[24]
+      assert_equal "CA", rows.first[25]
+      assert_equal "Résultat net", rows.first[26]
+      assert_equal "Résultat d'exploitation", rows.first[27]
+      assert_equal "Ratio de liquidité", rows.first[28]
+      assert_equal "45.123456", rows.second[24]
+      assert_equal "1234567", rows.second[25]
+      assert_equal "-12345", rows.second[26]
+      assert_equal "67890", rows.second[27]
+      assert_equal "98.765432", rows.second[28]
+    end
+
+    private
+
+    def worksheet_rows(xlsx)
+      Zip::File.open_buffer(StringIO.new(xlsx)) do |zip_file|
+        sheet_xml = zip_file.read("xl/worksheets/sheet1.xml")
+        document = Nokogiri::XML(sheet_xml)
+        namespace = { "x" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main" }
+
+        document.xpath("//x:sheetData/x:row", namespace).map do |row|
+          row.xpath("x:c", namespace).map { |cell| cell_value(cell, namespace) }
+        end
+      end
+    end
+
+    def cell_value(cell, namespace)
+      if cell["t"] == "inlineStr"
+        cell.at_xpath("x:is/x:t", namespace)&.text
+      else
+        cell.at_xpath("x:v", namespace)&.text
+      end
+    end
+  end
+end

--- a/test/services/excel/list_generator_test.rb
+++ b/test/services/excel/list_generator_test.rb
@@ -10,6 +10,24 @@ module Excel
       company = companies(:company_paris)
       list = lists(:list_test_2025)
 
+      create_inpi_bce_ratios(company)
+      rows = generated_rows(list, company)
+
+      assert_equal "Taux endettement", rows.first[24]
+      assert_equal "CA", rows.first[25]
+      assert_equal "Résultat net", rows.first[26]
+      assert_equal "Résultat d'exploitation", rows.first[27]
+      assert_equal "Ratio de liquidité", rows.first[28]
+      assert_equal "45.123456", rows.second[24]
+      assert_equal "1234567", rows.second[25]
+      assert_equal "-12345", rows.second[26]
+      assert_equal "67890", rows.second[27]
+      assert_equal "98.765432", rows.second[28]
+    end
+
+    private
+
+    def create_inpi_bce_ratios(company)
       InpiBceRatio.create!(
         siren: company.siren,
         date_cloture_exercice: Date.new(2022, 12, 31),
@@ -30,7 +48,9 @@ module Excel
         taux_d_endettement: 45.123456,
         ratio_de_liquidite: 98.765432
       )
+    end
 
+    def generated_rows(list, company)
       xlsx = ListGenerator.new(
         list,
         Company.where(siren: company.siren),
@@ -38,39 +58,30 @@ module Excel
         users(:user_crp_paris)
       ).generate
 
-      rows = worksheet_rows(xlsx)
-
-      assert_equal "Taux endettement", rows.first[24]
-      assert_equal "CA", rows.first[25]
-      assert_equal "Résultat net", rows.first[26]
-      assert_equal "Résultat d'exploitation", rows.first[27]
-      assert_equal "Ratio de liquidité", rows.first[28]
-      assert_equal "45.123456", rows.second[24]
-      assert_equal "1234567", rows.second[25]
-      assert_equal "-12345", rows.second[26]
-      assert_equal "67890", rows.second[27]
-      assert_equal "98.765432", rows.second[28]
+      worksheet_rows(xlsx)
     end
 
-    private
-
     def worksheet_rows(xlsx)
+      rows = nil
+
       Zip::File.open_buffer(StringIO.new(xlsx)) do |zip_file|
         sheet_xml = zip_file.read("xl/worksheets/sheet1.xml")
         document = Nokogiri::XML(sheet_xml)
-        namespace = { "x" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main" }
+        document.remove_namespaces!
 
-        document.xpath("//x:sheetData/x:row", namespace).map do |row|
-          row.xpath("x:c", namespace).map { |cell| cell_value(cell, namespace) }
+        rows = document.xpath("//sheetData/row").map do |row|
+          row.xpath("c").map { |cell| cell_value(cell) }
         end
       end
+
+      rows
     end
 
-    def cell_value(cell, namespace)
+    def cell_value(cell)
       if cell["t"] == "inlineStr"
-        cell.at_xpath("x:is/x:t", namespace)&.text
+        cell.at_xpath("is/t")&.text
       else
-        cell.at_xpath("x:v", namespace)&.text
+        cell.at_xpath("v")&.text
       end
     end
   end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `InpiBceRatio` storage for the BCE/INPI financial ratios dataset, related to companies by `siren`.
- Export the latest BCE/INPI ratio values in list XLSX files: taux endettement, CA, résultat net, résultat d'exploitation, and ratio de liquidité.
- Add a focused XLSX generation test covering the new columns and latest-ratio selection.

### Testing
- `docker compose -f docker-compose.yml -f <(printf 'services:\n  db:\n    image: postgres:16-alpine\n') run --rm -e RAILS_ENV=test web rails db:create db:migrate`
- `docker compose -f docker-compose.yml -f <(printf 'services:\n  db:\n    image: postgres:16-alpine\n') run --rm -e RAILS_ENV=test web rails test test/services/excel/list_generator_test.rb`
- `docker compose -f docker-compose.yml -f <(printf 'services:\n  db:\n    image: postgres:16-alpine\n') run --rm -e RAILS_ENV=test web rails test`
- `docker compose -f docker-compose.yml -f <(printf 'services:\n  db:\n    image: postgres:16-alpine\n') run --rm web bundle exec rubocop app/models/company.rb app/models/inpi_bce_ratio.rb app/services/excel/list_generator.rb test/services/excel/list_generator_test.rb db/migrate/20260511134000_create_inpi_bce_ratios.rb`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d3f2732-ba6d-4209-9add-6b5281bd71ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d3f2732-ba6d-4209-9add-6b5281bd71ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

