### PR TITLE
Feature/a11y multiselect focus

### DIFF
--- a/app/javascript/controllers/multiselect_controller.js
+++ b/app/javascript/controllers/multiselect_controller.js
@@ -49,6 +49,7 @@ export default class extends Controller {
   }
 
   handleClickOutside(event) {
+    if (!event.target.isConnected) return
     if (!this.element.contains(event.target)) {
       this.clearResults()
     }
@@ -88,6 +89,7 @@ export default class extends Controller {
       this.selectedItems.shift()
       this.updateHiddenField()
       this.renderTags()
+      this.refreshResultsIfOpen()
     } else if (['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(event.key)) {
       this.focusedOptionIndex = -1
       this.clearOptionFocus()
@@ -95,6 +97,10 @@ export default class extends Controller {
       this.focusedOptionIndex = -1
       this.clearOptionFocus()
     }
+  }
+
+  handleFocus() {
+    this.openIfClosed()
   }
 
   openIfClosed() {
@@ -252,8 +258,7 @@ export default class extends Controller {
 
     this.updateHiddenField()
     this.renderTags()
-    this.inputTarget.value = ""
-    this.clearResults()
+    this.refreshResultsIfOpen()
     this.inputTarget.focus()
   }
 
@@ -367,6 +372,11 @@ export default class extends Controller {
     if (tagItems[0].getBoundingClientRect().right > limit - badgeWidth) {
       tagItems[0].style.maxWidth = `${Math.max(limit - badgeWidth - tagLeft, 32)}px`
     }
+  }
+
+  refreshResultsIfOpen() {
+    const isOpen = this.resultsTarget.querySelector('.sf-multiselect-results') !== null
+    if (isOpen) this.performSearch(this.inputTarget.value.trim())
   }
 
   clearResults() {

--- a/app/views/establishment_trackings/_filters.html.erb
+++ b/app/views/establishment_trackings/_filters.html.erb
@@ -27,7 +27,7 @@
                               placeholder: "",
                               aria: { autocomplete: "list", controls: "sf-multiselect-departement-list", expanded: "false" },
                               role: "combobox",
-                              data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                              data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                               autocomplete: "off" %>
             </div>
             <%= f.hidden_field :establishment_departement_in_values,
@@ -64,7 +64,7 @@
                               placeholder: "",
                               aria: { autocomplete: "list", controls: "sf-multiselect-state-list", expanded: "false" },
                               role: "combobox",
-                              data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                              data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                               autocomplete: "off" %>
             </div>
             <%= f.hidden_field :state_in_values,
@@ -106,7 +106,7 @@
                                   placeholder: "",
                                   aria: { autocomplete: "list", controls: "sf-multiselect-labels-list", expanded: "false" },
                                   role: "combobox",
-                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                   autocomplete: "off" %>
                 </div>
                 <%= f.hidden_field :tracking_labels_id_in_values,
@@ -137,7 +137,7 @@
                                   placeholder: "",
                                   aria: { autocomplete: "list", controls: "sf-multiselect-services-list", expanded: "false" },
                                   role: "combobox",
-                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                   autocomplete: "off" %>
                 </div>
                 <%= f.hidden_field :supporting_services_id_in_values,
@@ -168,7 +168,7 @@
                                   placeholder: "",
                                   aria: { autocomplete: "list", controls: "sf-multiselect-sectors-list", expanded: "false" },
                                   role: "combobox",
-                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                   autocomplete: "off" %>
                 </div>
                 <%= f.hidden_field :sectors_id_in_values,

--- a/app/views/establishment_trackings/edit.html.erb
+++ b/app/views/establishment_trackings/edit.html.erb
@@ -89,7 +89,7 @@
                   <%= form.text_field :tracking_label_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-tracking-labels-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :tracking_label_ids_values,
@@ -121,7 +121,7 @@
                   <%= form.text_field :supporting_service_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-supporting-services-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :supporting_service_ids_values,
@@ -153,7 +153,7 @@
                   <%= form.text_field :difficulty_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-difficulties-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :difficulty_ids_values,
@@ -185,7 +185,7 @@
                   <%= form.text_field :user_action_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-user-actions-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :user_action_ids_values,
@@ -217,7 +217,7 @@
                   <%= form.text_field :codefi_redirect_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-codefi-redirects-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :codefi_redirect_ids_values,
@@ -260,7 +260,7 @@
                   <%= form.text_field :sector_ids, value: "", class: "fr-input", placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-sectors-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :sector_ids_values,

--- a/app/views/establishment_trackings/manage_contributors.html.erb
+++ b/app/views/establishment_trackings/manage_contributors.html.erb
@@ -46,7 +46,7 @@
                                 role: "combobox",
                                 data: {
                                   multiselect_target: "input",
-                                  action: "input->multiselect#search keydown->multiselect#handleKeydown"
+                                  action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus"
                                 },
                                 autocomplete: "off"
             %>
@@ -122,7 +122,7 @@
                                 role: "combobox",
                                 data: {
                                   multiselect_target: "input",
-                                  action: "input->multiselect#search keydown->multiselect#handleKeydown"
+                                  action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus"
                                 },
                                 autocomplete: "off"
             %>

--- a/app/views/establishment_trackings/new.html.erb
+++ b/app/views/establishment_trackings/new.html.erb
@@ -35,7 +35,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-referents-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :referent_ids_values,
@@ -76,7 +76,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-participants-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :participant_ids_values,
@@ -151,7 +151,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-labels-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :tracking_label_ids_values,
@@ -187,7 +187,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-supporting-services-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :supporting_service_ids_values,
@@ -223,7 +223,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-difficulties-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :difficulty_ids_values,
@@ -259,7 +259,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-user-actions-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :user_action_ids_values,
@@ -295,7 +295,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-codefi-redirects-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :codefi_redirect_ids_values,
@@ -345,7 +345,7 @@
                                       placeholder: "",
                                       aria: { autocomplete: "list", controls: "sf-multiselect-sectors-list", expanded: "false" },
                                       role: "combobox",
-                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                      data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                       autocomplete: "off" %>
                 </div>
                 <%= form.hidden_field :sector_ids_values,

--- a/app/views/lists/_search_form.html.erb
+++ b/app/views/lists/_search_form.html.erb
@@ -30,7 +30,7 @@
                               role: "combobox",
                               data: {
                                 multiselect_target: "input",
-                                action: "input->multiselect#search keydown->multiselect#handleKeydown"
+                                action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus"
                               },
                               autocomplete: "off"
               %>
@@ -76,7 +76,7 @@
                                   placeholder: "",
                                   aria: { autocomplete: "list", controls: "sf-multiselect-section-list", expanded: "false" },
                                   role: "combobox",
-                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                   autocomplete: "off" %>
                 </div>
                 <%= f.hidden_field :section_activite_principale_values,
@@ -100,7 +100,7 @@
                                   placeholder: "",
                                   aria: { autocomplete: "list", controls: "sf-multiselect-forme-list", expanded: "false" },
                                   role: "combobox",
-                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown" },
+                                  data: { multiselect_target: "input", action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus" },
                                   autocomplete: "off" %>
                 </div>
                 <%= f.hidden_field :forme_juridique_values,

--- a/app/views/pages/_search_form.html.erb
+++ b/app/views/pages/_search_form.html.erb
@@ -103,7 +103,7 @@
                               role: "combobox",
                               data: {
                                 multiselect_target: "input",
-                                action: "input->multiselect#search keydown->multiselect#handleKeydown"
+                                action: "input->multiselect#search keydown->multiselect#handleKeydown focus->multiselect#handleFocus"
                               },
                               autocomplete: "off"
               %>


### PR DESCRIPTION
Toujours ouvrir la liste quand le champ reçoit le focus : 
- y compris s'il y a une valeur déjà sélectionnée
- y compris s'il y a aucune valeur sélectionnée
- fonctionne au clavier et à la souris
- y compris après avoir sélectionné ou supprimé une valeur

Tous les champs multiselect sont mis à jour avec le nouvel évènement concernant le focus.